### PR TITLE
changed the controllers/Repo/Mirror/Rpm.php to check /repodata/repomd.xml

### DIFF
--- a/www/controllers/Repo/Mirror/Rpm.php
+++ b/www/controllers/Repo/Mirror/Rpm.php
@@ -530,7 +530,7 @@ class Rpm extends \Controllers\Repo\Mirror\Mirror
          */
         foreach ($this->archUrls as $arch => $archUrls) {
             foreach ($archUrls as $url) {
-                if (!\Controllers\Common::urlFileExists($url . '/repodata', $this->sslCustomCertificate, $this->sslCustomPrivateKey)) {
+                if (!\Controllers\Common::urlFileExists($url . '/repodata/repomd.xml', $this->sslCustomCertificate, $this->sslCustomPrivateKey)) {
                     // $this->logOutput(' - ' . $url . ' (unreachable or nothing here?)' . PHP_EOL);
 
                     /**

--- a/www/controllers/Repo/Package.php
+++ b/www/controllers/Repo/Package.php
@@ -178,7 +178,6 @@ class Package
              *  If there has been no error so far, then we can move the file to its final location
              */
             if ($uploadError == 0 and file_exists($packageTmpName)) {
-
                 /**
                  *  Create the target dir
                  */

--- a/www/public/custom_errors/custom_404.html
+++ b/www/public/custom_errors/custom_404.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>Page not found</title>
-        <link rel="stylesheet" type="text/css" href="../../resources/styles/custom_errors.css">
+        <link rel="stylesheet" type="text/css" href="/resources/styles/custom_errors.css">
     </head>
     <body>
         <div id="errorDiv-container">

--- a/www/public/custom_errors/custom_413.html
+++ b/www/public/custom_errors/custom_413.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>Error</title>
-        <link rel="stylesheet" type="text/css" href="../../resources/styles/custom_errors.css">
+        <link rel="stylesheet" type="text/css" href="/resources/styles/custom_errors.css">
     </head>
     <body>
         <div id="errorDiv-container">

--- a/www/public/custom_errors/custom_50x.html
+++ b/www/public/custom_errors/custom_50x.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>Error</title>
-        <link rel="stylesheet" type="text/css" href="../../resources/styles/custom_errors.css">
+        <link rel="stylesheet" type="text/css" href="/resources/styles/custom_errors.css">
     </head>
     <body>
         <div id="errorDiv-container">


### PR DESCRIPTION
I made a simple change to the `controllers/Repo/Mirror/Rpm.php` file to check `/repodata/repomd.xml` instead of the `/repodata` directory. Some RPM repositories are configured to prohibit access to the directory itself while the files under it is allowed.