### PR TITLE
Include port for WebSocket

### DIFF
--- a/www/public/resources/js/functions.js
+++ b/www/public/resources/js/functions.js
@@ -3,7 +3,7 @@
  */
 function websocket_client()
 {
-    const server = window.location.hostname;
+    const server = window.location.host;
 
     // If the target server uses https, then use wss://
     if (window.location.protocol == 'https:') {


### PR DESCRIPTION
Hi,

I just started to play around with repomanager and saw that if you use a diffrent port it will not be used for the WebSocket.
This fixed it for me 😉 

Greeting,
pottah