### PR TITLE
feat(templates): add pve 9 repos

### DIFF
--- a/www/templates/source-repositories/deb/proxmox-ve.yml
+++ b/www/templates/source-repositories/deb/proxmox-ve.yml
@@ -7,6 +7,14 @@ repositories:
     description: Proxmox Virtual Environment Public Repositories
     url: http://download.proxmox.com/debian/pve
     distributions:
+      - name: trixie
+        description: PVE 9 for Debian Trixie
+        components:
+          - name: pve-no-subscription
+          - name: pve-test
+        gpgkeys:
+          - fingerprint: 24B30F06ECC1836A4E5EFECBA7BCD1420BFE778E
+          - link: https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg
       - name: bookworm
         description: PVE 8 for Debian Bookworm
         components:
@@ -67,6 +75,13 @@ repositories:
     description: Proxmox Virtual Environment Enterprise Repositories
     url: https://enterprise.proxmox.com/debian/pve
     distributions:
+      - name: trixie
+        description: PVE 9 for Debian Trixie
+        components:
+          - name: pve-enterprise
+        gpgkeys:
+          - fingerprint: 24B30F06ECC1836A4E5EFECBA7BCD1420BFE778E
+          - link: https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg
       - name: bookworm
         description: PVE 8 for Debian Bookworm
         components:


### PR DESCRIPTION
This adds the pve9 repositories to the templates.
The only notable change from previous versions is the test repository component name, which is now `pve-test`.
( https://pve.proxmox.com/pve-docs/pve-admin-guide.html#sysadmin_package_repositories )

Thanks for this project!