### PR TITLE
Upgrade Docker environment: Debian 13, PHP 8.4, generic PHP-FPM socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for Repomanager
 
 # Base image
-FROM debian:12-slim AS base
+FROM debian:13-slim AS base
 
 # Metadata
 LABEL version="1.2" maintainer="lbr38 <repomanager@protonmail.com>"
@@ -10,7 +10,7 @@ LABEL version="1.2" maintainer="lbr38 <repomanager@protonmail.com>"
 ARG WWW_DIR="/var/www/repomanager"
 ARG DATA_DIR="/var/lib/repomanager"
 ARG REPOS_DIR="/home/repo"
-ARG PHP_VERSION="8.3"
+ARG PHP_VERSION="8.4"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG branch=main
 
@@ -18,19 +18,20 @@ ARG branch=main
 ENV BRANCH=${branch}
 
 # PACKAGES INSTALL
-# Add nginx and PHP 8.3 repositories
+# Add nginx and PHP 8.4 repositories
 ADD https://packages.repomanager.net/repo/gpgkeys/packages.repomanager.net.pub /tmp/packages.repomanager.net.gpg
 RUN apt-get update -y -qq && apt-get install -y -qq gnupg2 ca-certificates && rm -rf /var/lib/apt/lists/* && \
     cat /tmp/packages.repomanager.net.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/packages.repomanager.net.gpg && rm -f /tmp/packages.repomanager.net.gpg
-RUN echo "deb https://packages.repomanager.net/repo/deb/repomanager-nginx/bookworm/nginx/prod bookworm nginx" > /etc/apt/sources.list.d/nginx.list && \
-    echo "deb https://packages.repomanager.net/repo/deb/repomanager-php/bookworm/main/prod bookworm main" > /etc/apt/sources.list.d/php.list
+#RUN echo "deb https://packages.repomanager.net/repo/deb/repomanager-nginx/bookworm/nginx/prod bookworm nginx" > /etc/apt/sources.list.d/nginx.list && \
+#    echo "deb https://packages.repomanager.net/repo/deb/repomanager-php/bookworm/main/prod bookworm main" > /etc/apt/sources.list.d/php.list
 
 # Install dependencies
-RUN apt-get update -y -qq && \
-    apt-get install -y -qq findutils iputils-ping git rpm librpmsign9 createrepo-c apt-utils curl apt-transport-https dnsutils xz-utils bzip2 zstd vim python3-psutil \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y -qq && \
+    apt-get install -y -qq findutils iputils-ping git rpm librpmsign10 createrepo-c apt-utils curl apt-transport-https dnsutils xz-utils bzip2 zstd vim python3-psutil \
     # Install postfix
     postfix \
-    # Install nginx and PHP 8.3
+    # Install nginx and PHP 8.4
     nginx php${PHP_VERSION}-fpm php${PHP_VERSION}-cli php${PHP_VERSION}-sqlite3 php${PHP_VERSION}-xml php${PHP_VERSION}-curl php${PHP_VERSION}-yaml php${PHP_VERSION}-opcache sqlite3 \
     # Install xdebug if branch is devel
     $(if [ "$branch" = "devel" ]; then echo "php${PHP_VERSION}-xdebug"; fi) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENV BRANCH=${branch}
 ADD https://packages.repomanager.net/repo/gpgkeys/packages.repomanager.net.pub /tmp/packages.repomanager.net.gpg
 RUN apt-get update -y -qq && apt-get install -y -qq gnupg2 ca-certificates && rm -rf /var/lib/apt/lists/* && \
     cat /tmp/packages.repomanager.net.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/packages.repomanager.net.gpg && rm -f /tmp/packages.repomanager.net.gpg
-#RUN echo "deb https://packages.repomanager.net/repo/deb/repomanager-nginx/bookworm/nginx/prod bookworm nginx" > /etc/apt/sources.list.d/nginx.list && \
-#    echo "deb https://packages.repomanager.net/repo/deb/repomanager-php/bookworm/main/prod bookworm main" > /etc/apt/sources.list.d/php.list
+#RUN echo "deb https://packages.repomanager.net/repo/deb/repomanager-nginx/trixie/main/prod trixie nginx" > /etc/apt/sources.list.d/nginx.list && \
+#    echo "deb https://packages.repomanager.net/repo/deb/repomanager-php/trixie/main/prod trixie main" > /etc/apt/sources.list.d/php.list
 
 # Install dependencies
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/docker/config/nginx/repomanager.conf
+++ b/docker/config/nginx/repomanager.conf
@@ -8,7 +8,7 @@ map $request_uri $loggable {
 
 # Path to unix socket
 upstream php-handler {
-    server unix:/run/php/php8.3-fpm.sock;
+    server unix:/run/php/php8.4-fpm.sock;
 }
 
 server {

--- a/docker/config/nginx/repomanager.conf
+++ b/docker/config/nginx/repomanager.conf
@@ -8,7 +8,7 @@ map $request_uri $loggable {
 
 # Path to unix socket
 upstream php-handler {
-    server unix:/run/php/php8.4-fpm.sock;
+    server unix:/run/php/php-fpm.sock;
 }
 
 server {

--- a/docker/config/php/www.conf
+++ b/docker/config/php/www.conf
@@ -33,7 +33,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php/php8.3-fpm.sock
+listen = /run/php/php8.4-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/docker/config/php/www.conf
+++ b/docker/config/php/www.conf
@@ -33,7 +33,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php/php8.4-fpm.sock
+listen = /run/php/php-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/docker/init
+++ b/docker/init
@@ -3,6 +3,7 @@ set -e
 
 WWW_DIR="/var/www/repomanager"
 DATA_DIR="/var/lib/repomanager"
+PHP_VERSION="8.4"
 
 # Docker environment variables
 #  - FQDN=server.example.com
@@ -58,13 +59,13 @@ if [ ! -z "$MAX_UPLOAD_SIZE" ];then
     # Nginx configuration
     sed -i "s/client_max_body_size.*$/client_max_body_size ${MAX_UPLOAD_SIZE};/g" /etc/nginx/sites-enabled/repomanager.conf
     # PHP configuration
-    sed -i "s/^upload_max_filesize.*$/upload_max_filesize = ${MAX_UPLOAD_SIZE}/g" /etc/php/8.3/fpm/php.ini
-    sed -i "s/^post_max_size.*$/post_max_size = ${MAX_UPLOAD_SIZE}/g" /etc/php/8.3/fpm/php.ini
+    sed -i "s/^upload_max_filesize.*$/upload_max_filesize = ${MAX_UPLOAD_SIZE}/g" /etc/php/${PHP_VERSION}/fpm/php.ini
+    sed -i "s/^post_max_size.*$/post_max_size = ${MAX_UPLOAD_SIZE}/g" /etc/php/${PHP_VERSION}/fpm/php.ini
 fi
 
 # Set PHP memory limit
 if [ ! -z "$PHP_MEMORY_LIMIT" ];then
-    sed -i "s/^memory_limit.*$/memory_limit = ${PHP_MEMORY_LIMIT}/g" /etc/php/8.3/fpm/php.ini
+    sed -i "s/^memory_limit.*$/memory_limit = ${PHP_MEMORY_LIMIT}/g" /etc/php/${PHP_VERSION}/fpm/php.ini
 fi
 
 # Set Nginx listen port
@@ -100,7 +101,7 @@ fi
 
 # Start services
 echo "["$(date +"%a %b %-d %H:%M:%S")"][INF] Starting php-fpm..."
-/usr/sbin/service php8.3-fpm start > /dev/null
+/usr/sbin/service php${PHP_VERSION}-fpm start > /dev/null
 echo "["$(date +"%a %b %-d %H:%M:%S")"][INF] Starting nginx..."
 /usr/sbin/service nginx start > /dev/null
 echo "["$(date +"%a %b %-d %H:%M:%S")"][INF] Starting postfix..."
@@ -131,7 +132,7 @@ terminate() {
     /usr/sbin/service nginx stop > /dev/null
 
     echo "["$(date +"%a %b %-d %H:%M:%S")"][INF] Stopping php-fpm..."
-    /usr/sbin/service php8.3-fpm stop > /dev/null
+    /usr/sbin/service php${PHP_VERSION}-fpm stop > /dev/null
     exit
 }
 


### PR DESCRIPTION
### Summary

This MR updates the Docker environment to use newer base components and simplifies PHP-FPM socket handling inside the container.

### Changes
- **Base image updated** from `debian:12-slim` to `debian:13-slim`.
- **PHP** upgraded from **8.3** to **8.4**.
- **PHP-FPM socket changed to a non-versioned path** (/run/php/php-fpm.sock).

### Details
**Debian upgrade**

The base image is upgraded to Debian 13 (trixie) to align the container with newer upstream packages and security updates.

**PHP upgrade**

PHP is upgraded from 8.3 → 8.4, and all related packages are updated accordingly.

Exception is for php library: `symfony/polyfill-php83` (unfortunately, I'm not web guy)

**Non-versioned PHP-FPM socket**

The PHP-FPM socket path has been changed from a versioned path:

`/run/php/php8.3-fpm.sock`

to a generic socket:

`/run/php/php-fpm.sock`

This simplifies configuration and removes the need to update Nginx or service scripts when PHP versions change.

Since this image runs inside Docker and only a single PHP version is present, using a non-versioned socket path is safe and improves maintainability.

### Benefits
- Easier PHP version upgrades in the future.
- Cleaner configuration (no version coupling in Nginx or scripts).
- Alignment with newer Debian and PHP releases.

### Notes

The `Dockerfile` contains references to the `packages.repomanager.net` repository. 
Since these repositories for `trixie` are not currently available, the corresponding lines are commented out.