### PR TITLE
Add Ubuntu 26.04 source repository templates

### DIFF
--- a/www/config/properties.php
+++ b/www/config/properties.php
@@ -21,6 +21,7 @@ $config = [
         'stretch' => 'Debian 9',
         'jessie' => 'Debian 8',
         'wheezy' => 'Debian 7',
+        'resolute' => 'Ubuntu 26.04',
         'noble' => 'Ubuntu 24.04',
         'jammy' => 'Ubuntu 22.04',
         'hirsute' => 'Ubuntu 21.04',

--- a/www/templates/source-repositories/deb/docker-ubuntu.yml
+++ b/www/templates/source-repositories/deb/docker-ubuntu.yml
@@ -7,6 +7,14 @@ repositories:
     description: Docker repository
     url: https://download.docker.com/linux/ubuntu
     distributions:
+      # Ubuntu 26.04
+      - name: resolute
+        description: Ubuntu 26.04
+        components:
+          - name: stable
+        gpgkeys:
+          - link: https://download.docker.com/linux/ubuntu/gpg
+
       # Ubuntu 24.04
       - name: noble
         description: Ubuntu 24.04

--- a/www/templates/source-repositories/deb/ubuntu.yml
+++ b/www/templates/source-repositories/deb/ubuntu.yml
@@ -7,6 +7,17 @@ repositories:
     description: Ubuntu official repositories
     url: http://archive.ubuntu.com/ubuntu
     distributions:
+      # Ubuntu 26.04
+      - name: resolute
+        description: Ubuntu 26.04
+        components:
+          - name: main
+          - name: restricted
+          - name: universe
+          - name: multiverse
+        gpgkeys:
+          - fingerprint: F6ECB3762474EDA9D21B7022871920D1991BC93C
+
       # Ubuntu 24.04
       - name: noble
         description: Ubuntu 24.04
@@ -46,6 +57,28 @@ repositories:
     url: http://security.ubuntu.com/ubuntu
     description: Ubuntu security repositories
     distributions:
+      # Ubuntu 26.04
+      - name: resolute-security
+        description: Ubuntu 26.04 Security Updates
+        components:
+          - name: main
+          - name: restricted
+          - name: universe
+          - name: multiverse
+        gpgkeys:
+          - fingerprint: F6ECB3762474EDA9D21B7022871920D1991BC93C
+
+      # Ubuntu 26.04
+      - name: resolute-updates
+        description: Ubuntu 26.04 Updates
+        components:
+          - name: main
+          - name: restricted
+          - name: universe
+          - name: multiverse
+        gpgkeys:
+          - fingerprint: F6ECB3762474EDA9D21B7022871920D1991BC93C
+
       # Ubuntu 24.04
       - name: noble-updates
         description: Ubuntu 24.04 Security Updates


### PR DESCRIPTION
## Summary

- Add Ubuntu 26.04 resolute to official Ubuntu source repository templates
- Add resolute-security and resolute-updates entries
- Add Ubuntu 26.04 resolute to Docker Ubuntu source repository templates
- Add resolute to default DEB distribution labels

## Testing

- Parsed updated YAML templates successfully