### PR TITLE
Document local Docker Compose development

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,28 @@
+services:
+  repomanager:
+    container_name: repomanager-local
+    image: repomanager-local
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        branch: devel
+    environment:
+      FQDN: localhost
+      MAX_UPLOAD_SIZE: 64M
+      NGINX_LISTEN_PORT: 8888
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+    ports:
+      - "8888:8888"
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./www:/var/www/repomanager
+      - repomanager-local-data:/var/lib/repomanager
+      - repomanager-local-repo:/home/repo
+      - repomanager-local-logs:/var/log/nginx
+
+volumes:
+  repomanager-local-data:
+  repomanager-local-repo:
+  repomanager-local-logs:

--- a/documentation/docs/getting-started/alternative-installation.md
+++ b/documentation/docs/getting-started/alternative-installation.md
@@ -13,4 +13,31 @@ Replace the variables in ``roles/repomanager/vars/repomanager.yml``, add the rol
 
 Some users managed to install Repomanager inside a Kubernetes cluster but this is not officially documented yet.
 
+## :simple-docker: Local development with Docker Compose
+
+For local development, you can build and run Repomanager with the provided Docker Compose file:
+
+```bash
+PUID=$(id -u) PGID=$(id -g) docker compose -f docker-compose.local.yml up --build
+```
+
+The local Compose file:
+
+- binds the web interface to `http://localhost:8888`
+- bind-mounts `./www` into the container so source changes are visible immediately
+- stores application data and repositories in named Docker volumes
+- passes your local user and group IDs to avoid root-owned files in the working tree
+
+Default login:
+
+```text
+admin / repomanager
+```
+
+Stop the local instance with:
+
+```bash
+docker compose -f docker-compose.local.yml down
+```
+
 <script data-goatcounter="https://repomanager.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
Adds documentation for running Repomanager locally with Docker Compose during development.