### PR TITLE
Normalize DEB distribution aliases

### DIFF
--- a/www/controllers/Task/Form/Form.php
+++ b/www/controllers/Task/Form/Form.php
@@ -116,9 +116,9 @@ class Form
      *  Validate the task form filled by the user
      *  @param array $tasksParams
      */
-    public function validate(array $tasksParams) : void
+    public function validate(array &$tasksParams) : void
     {
-        foreach ($tasksParams as $task) {
+        foreach ($tasksParams as &$task) {
             /**
              *  Retrieve action
              */
@@ -150,10 +150,19 @@ class Form
             }
 
             /**
+             *  Normalize known DEB distribution aliases before validation and task execution.
+             */
+            if ($task['action'] == 'create' and ($task['package-type'] ?? '') == 'deb' and !empty($task['dist'])) {
+                $task['dist'] = Param\Dist::normalize($task['dist']);
+            }
+
+            /**
              *  Validate form by calling the controller
              */
             $controller = new $controllerPath();
             $controller->validate($task);
         }
+
+        unset($task);
     }
 }

--- a/www/controllers/Task/Form/Param/Dist.php
+++ b/www/controllers/Task/Form/Param/Dist.php
@@ -7,6 +7,21 @@ use Controllers\Utils\Validate;
 
 class Dist
 {
+    /**
+     *  Normalize known distribution aliases to their canonical codenames.
+     */
+    public static function normalize(array $dists) : array
+    {
+        $normalizedDists = [];
+        $aliases = self::aliases();
+
+        foreach ($dists as $dist) {
+            $normalizedDists[] = $aliases[strtolower(trim($dist))] ?? $dist;
+        }
+
+        return array_values(array_unique($normalizedDists));
+    }
+
     public static function check(array $dists) : void
     {
         if (empty($dists)) {
@@ -18,5 +33,29 @@ class Dist
                 throw new Exception('Distribution name cannot contain special characters except hyphen');
             }
         }
+    }
+
+    /**
+     *  Build aliases from configured DEB distributions.
+     */
+    private static function aliases() : array
+    {
+        $aliases = [];
+
+        foreach (DEB_DISTRIBUTIONS as $distributionName => $distributionDescription) {
+            $name = strtolower($distributionName);
+            $description = strtolower($distributionDescription);
+            $aliases[$name] = $distributionName;
+            $aliases[$description] = $distributionName;
+
+            if (preg_match('/^(?<family>[a-z]+)\s+(?<version>[0-9]+(?:\.[0-9]+)?)/i', $distributionDescription, $matches)) {
+                $version = strtolower($matches['version']);
+                $family = strtolower($matches['family']);
+                $aliases[$version] = $distributionName;
+                $aliases[$family . ' ' . $version] = $distributionName;
+            }
+        }
+
+        return $aliases;
     }
 }


### PR DESCRIPTION
Normalizes DEB distribution aliases in task form validation so version labels map to their codename values before execution.