### PR TITLE
mod: no need to set owner new if it is already ok

### DIFF
--- a/www/bin/repomanager
+++ b/www/bin/repomanager
@@ -51,18 +51,28 @@ function permissions
     fi
 
     echo "["$(date +"%a %b %-d %H:%M:%S")"][INF] Setting permissions... "
- 
+
+    setUID=$(grep www-data /etc/passwd | awk -F ':' '{print $3}')
+    setGID=$(grep www-data /etc/passwd | awk -F ':' '{print $4}')
+
     # Make sure owner and group and permissions are correct on parent directories
     chown www-data:www-data "$WWW_DIR" "$DATA_DIR" "$REPOS_DIR"
     chmod 770 "$WWW_DIR" "$DATA_DIR" "$REPOS_DIR"
 
     # Now go deeper and set permissions recursively
-    chown -R www-data:www-data "$WWW_DIR" > /dev/null 2>&1
-    chown -R www-data:www-data "$DATA_DIR" > /dev/null 2>&1
+    # First check, than set
+    for DIR in ${WWW_DIR} ${DATA_DIR}; do
+        if [ "$(find ${DIR} \( ! -uid ${setUID} -o ! -gid ${setGID} \) | wc -l)" -gt "0" ]; then
+            chown -R ${setUID}:${setGID} "$DIR" > /dev/null 2>&1
+        fi
+    done
     # For repositories, run in background to avoid long wait
-    chown -R www-data:www-data "$REPOS_DIR" > /dev/null 2>&1 &
+    # First check, than set
+    (if [ "$(find ${REPOS_DIR} \( ! -uid ${setUID} -o ! -gid ${setGID} \) | wc -l)" -gt "0" ]; then
+        chown -R ${setUID}:${setGID} "$REPOS_DIR" > /dev/null 2>&1
+    fi) &
 
-    # Permissions on /.gnupg directory
+# Permissions on /.gnupg directory
     if [ -d "$GPGHOME" ];then
         chmod 700 $GPGHOME
 


### PR DESCRIPTION
Checking all files is way faster then setting all files.

If the check fails it still can set the ownership correctly.