### PR TITLE
mod: first check then chown

### DIFF
--- a/www/bin/repomanager
+++ b/www/bin/repomanager
@@ -52,15 +52,25 @@ function permissions
 
     echo "["$(date +"%a %b %-d %H:%M:%S")"][INF] Setting permissions... "
  
+    setUID=$(grep www-data /etc/passwd | awk -F ':' '{print $3}')
+    setGID=$(grep www-data /etc/passwd | awk -F ':' '{print $4}')
+
     # Make sure owner and group and permissions are correct on parent directories
     chown www-data:www-data "$WWW_DIR" "$DATA_DIR" "$REPOS_DIR"
     chmod 770 "$WWW_DIR" "$DATA_DIR" "$REPOS_DIR"
 
     # Now go deeper and set permissions recursively
-    chown -R www-data:www-data "$WWW_DIR" > /dev/null 2>&1
-    chown -R www-data:www-data "$DATA_DIR" > /dev/null 2>&1
+    # First check, than set
+    for DIR in ${WWW_DIR} ${DATA_DIR}; do
+        if [ "$(find ${DIR} \( ! -uid ${setUID} -o ! -gid ${setGID} \) | wc -l)" -gt "0" ]; then
+            chown -R ${setUID}:${setGID} "$DIR" > /dev/null 2>&1
+        fi
+    done
     # For repositories, run in background to avoid long wait
-    chown -R www-data:www-data "$REPOS_DIR" > /dev/null 2>&1 &
+    # First check, than set
+    (if [ "$(find ${REPOS_DIR} \( ! -uid ${setUID} -o ! -gid ${setGID} \) | wc -l)" -gt "0" ]; then
+        chown -R ${setUID}:${setGID} "$REPOS_DIR" > /dev/null 2>&1
+    fi) &
 
     # Permissions on /.gnupg directory
     if [ -d "$GPGHOME" ];then


### PR DESCRIPTION
As we restart our repomanager a lot, we noticed there is a chown running minutes.
Whilst this everything is very slow.

Checking is way faster than setting.

So first check, if it fails set the ownership new.